### PR TITLE
Only serve /dist when in production mode

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,8 +10,6 @@ const isDeveloping = process.env.NODE_ENV !== 'production';
 const port = isDeveloping ? 3000 : process.env.PORT;
 const app = express();
 
-app.use(express.static(__dirname + '/dist'));
-
 if (isDeveloping) {
   const compiler = webpack(config);
 
@@ -29,6 +27,9 @@ if (isDeveloping) {
   }));
 
   app.use(webpackHotMiddleware(compiler));
+}
+else {
+  app.use(express.static(__dirname + '/dist'));
 }
 
 app.get('*', function response(req, res) {


### PR DESCRIPTION
Current if we run `npm run build` followed by `npm start` without removing `/dist` then it will appear that webpack is serving the files but really express is just serving them statically.
