### PR TITLE
fix: bind to IP 0.0.0.0 instead of localhost

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,9 +35,9 @@ app.get('*', function response(req, res) {
   res.sendFile(path.join(__dirname, 'dist/index.html'));
 });
 
-app.listen(port, 'localhost', function onStart(err) {
+app.listen(port, '0.0.0.0', function onStart(err) {
   if (err) {
     console.log(err);
   }
-  console.info('==> 🌎 Listening on port %s. Open up http://localhost:%s/ in your browser.', port, port);
+  console.info('==> 🌎 Listening on port %s. Open up http://0.0.0.0:%s/ in your browser.', port, port);
 });


### PR DESCRIPTION
When binding to localhost within a docker container and using docker-compose to compose multiple docker containers together the binding can get lost, as hostnames are juggled around by docker. Binding to `0.0.0.0` fixes this. On a "normal" system, this change makes no difference.
