### PR TITLE
Use in memory fs from webpack when in development mode.

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,8 +14,7 @@ app.use(express.static(__dirname + '/dist'));
 
 if (isDeveloping) {
   const compiler = webpack(config);
-
-  app.use(webpackMiddleware(compiler, {
+  const middleware = webpackMiddleware(compiler, {
     publicPath: config.output.publicPath,
     contentBase: 'src',
     stats: {
@@ -26,14 +25,20 @@ if (isDeveloping) {
       chunkModules: false,
       modules: false
     }
-  }));
+  });
 
+  app.use(middleware);
   app.use(webpackHotMiddleware(compiler));
-}
 
-app.get('*', function response(req, res) {
-  res.sendFile(path.join(__dirname, 'dist/index.html'));
-});
+  app.get('*', function response(req, res) {
+    res.write(middleware.fileSystem.readFileSync(path.join(__dirname, 'dist/index.html')));
+    res.end();
+  });
+} else {
+  app.get('*', function response(req, res) {
+    res.sendFile(path.join(__dirname, 'dist/index.html'));
+  });
+}
 
 app.listen(port, 'localhost', function onStart(err) {
   if (err) {


### PR DESCRIPTION
Webpack middleware serves files from an in memory file system, which should be used when accessing any of the generated files during development.
