### PR TITLE
add webpack-node-externals

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "autoprefixer": "^6.0.3",
     "babel-eslint": "^4.1.6",
-    "babel-loader": "^6.2.3",
     "babel-jscs": "^2.0.5",
+    "babel-loader": "^6.2.3",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.1.0",
@@ -61,6 +61,7 @@
     "style-loader": "^0.12.4",
     "webpack": "^1.12.2",
     "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^2.2.0"
+    "webpack-hot-middleware": "^2.2.0",
+    "webpack-node-externals": "^1.2.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@
 var path = require('path');
 var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   devtool: 'eval-source-map',
@@ -28,6 +29,7 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify('development')
     })
   ],
+  externals: [nodeExternals()],
   module: {
     loaders: [{
       test: /\.js?$/,

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -5,6 +5,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var StatsPlugin = require('stats-webpack-plugin');
+var nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   entry: [
@@ -37,6 +38,7 @@ module.exports = {
       'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV)
     })
   ],
+  externals: [nodeExternals()],
   module: {
     loaders: [{
       test: /\.js?$/,


### PR DESCRIPTION
By adding this lib it is possible to add any node external lib without compilation problem. 
webpack ignore all 'node exclusive' libs
