### PR TITLE
Support loading of both .jsx and .js files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
   ],
   module: {
     loaders: [{
-      test: /\.js?$/,
+      test: /\.jsx?$/,
       exclude: /node_modules/,
       loader: 'babel',
       query: {

--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -39,7 +39,7 @@ module.exports = {
   ],
   module: {
     loaders: [{
-      test: /\.js?$/,
+      test: /\.jsx?$/,
       exclude: /node_modules/,
       loader: 'babel',
       query: {


### PR DESCRIPTION
### What does this PR do
- It modifies the regExp used by the babel loader to support both `.js` and `.jsx` scripts.
- Resolves #50 
