### PR TITLE
Add babel-core as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "babel-cli": "^6.4.0",
+    "babel-core": "^6.22.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3"
   },


### PR DESCRIPTION
Despite having babel installed as a global dependency, I had a weird error when trying to run this project (on Windows):

```
> node server

==> � Listening on port 3000. Open up http://0.0.0.0:3000/ in your browser.
webpack built ad46f686c7e5e05ceaeb in 1810ms
Version: webpack 1.14.0
Time: 1810ms
  Asset    Size  Chunks       Chunk Names
main.js  230 kB       0       main

ERROR in ./app/main.js
Module build failed: ReferenceError: [BABEL] .\webpack-express-boilerplate\app\main.js: Unknown option: direct.presets
    at Logger.error (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\file\logger.js:58:11)
    at OptionManager.mergeOptions (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\file\options\option-manager.js:126:29)
    at OptionManager.init (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\file\options\option-manager.js:216:10)
    at File.initOptions (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\file\index.js:147:75)
    at new File (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\file\index.js:137:22)
    at Pipeline.transform (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-core\lib\transformation\pipeline.js:164:16)
    at transpile (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-loader\lib\index.js:38:20)
    at Object.module.exports (D:\Coding\instaStack\webpack-express-boilerplate\node_modules\babel-loader\lib\index.js:133:12)
 @ multi main
webpack: bundle is now VALID.
```

Even though the output says that the bundle is "VALID", opening localhost:3000 yields another error. Adding babel-core as a dependency resolves the issue for me.