### PR TITLE
Only require devDependencies when NODE_ENV is not production

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "babel-cli": "^6.4.0",
     "babel-core": "^6.22.1",
     "react": "^0.14.3",
-    "react-dom": "^0.14.3"
+    "react-dom": "^0.14.3",
+    "express": "^4.13.3"
   },
   "devDependencies": {
     "autoprefixer": "^6.0.3",
@@ -45,7 +46,6 @@
     "css-loader": "^0.19.0",
     "eslint": "^1.5.0",
     "eslint-plugin-react": "^3.4.2",
-    "express": "^4.13.3",
     "extract-text-webpack-plugin": "^0.8.2",
     "html-webpack-plugin": "^1.6.1",
     "jscs": "^2.1.1",

--- a/server.js
+++ b/server.js
@@ -2,16 +2,16 @@
 
 const path = require('path');
 const express = require('express');
-const webpack = require('webpack');
-const webpackMiddleware = require('webpack-dev-middleware');
-const webpackHotMiddleware = require('webpack-hot-middleware');
-const config = require('./webpack.config.js');
 
 const isDeveloping = process.env.NODE_ENV !== 'production';
 const port = isDeveloping ? 3000 : process.env.PORT;
 const app = express();
 
 if (isDeveloping) {
+  const webpack = require('webpack');
+  const webpackMiddleware = require('webpack-dev-middleware');
+  const webpackHotMiddleware = require('webpack-hot-middleware');
+  const config = require('./webpack.config.js');
   const compiler = webpack(config);
   const middleware = webpackMiddleware(compiler, {
     publicPath: config.output.publicPath,


### PR DESCRIPTION
Fixes #66 

When `NODE_ENV=production` by default npm will not install `devDependencies`, and it is considered a best practice to not deploy your application with any `devDependencies` installed, otherwise they are direct dependencies of your application.

However if you try to do that with this boilerplate it will crash since it requires `webpack` and related tools even in production. This PR moves those requires behind the conditional and relocates `express` to `dependencies` since it's required at both build time and in production.